### PR TITLE
Utilise "packages:" feature instead of raw Include directive allowing easy integration with existing device configs

### DIFF
--- a/ESP32C3_Inkbird_IHT_2PB.yaml
+++ b/ESP32C3_Inkbird_IHT_2PB.yaml
@@ -36,5 +36,5 @@ captive_portal:
 bluetooth_proxy:
   active: true
 
-
-<<: !include Inkbird_IHT_2PB.yaml
+packages:
+  ink_bird: !include Inkbird_IHT_2PB.yaml

--- a/ESP32doit_Inkbird_IHT_2PB.yaml
+++ b/ESP32doit_Inkbird_IHT_2PB.yaml
@@ -32,4 +32,5 @@ captive_portal:
 bluetooth_proxy:
   active: true
 
-<<: !include Inkbird_IHT_2PB.yaml
+packages:
+  ink_bird: !include Inkbird_IHT_2PB.yaml


### PR DESCRIPTION
Existing users of esp-home have devices configured with buttons, switches and other complex logic established. The Include directive pulls in a separate file verbatim and neglects to merge node-wise into an existing configuration. 

Packages allows node-wise merging that enables easy integration of additional configuration into existing device configs.

Add the following to any existing esp-home config;

```
packages:
  ink_bird: !include Inkbird_IHT_2PB.yaml
```